### PR TITLE
Fix ansi color escape code

### DIFF
--- a/vars/log.groovy
+++ b/vars/log.groovy
@@ -1,11 +1,11 @@
 def info(message) {
     ansiColor('xterm') {
-        echo "\u001B[32mINFO: ${message}\u001B[m"
+        echo "\u001B[32mINFO: ${message}\u001B[0m"
     }
 }
 
 def warning(message) {
     ansiColor('xterm') {
-        echo "\u001B[31mWARNING: ${message}\u001B[m"
+        echo "\u001B[31mWARNING: ${message}\u001B[0m"
     }
 }


### PR DESCRIPTION
The tail part of the ansi code is not correct. Therefore the standard tools fail to strip the ansi code.