### PR TITLE
in case of cherry pick  rhevm_qe_infra_url is missing

### DIFF
--- a/vars/job_monitoring.groovy
+++ b/vars/job_monitoring.groovy
@@ -99,6 +99,7 @@ def call(Map config = [:]) {
 
     clone_infra_repo()
     def rhevm_qe_infra_dir = "${WORKSPACE}/rhevm-qe-infra"
+    def rhevm_qe_infra_url = "https://code.engineering.redhat.com/gerrit/rhevm-qe-automation/rhevm-qe-infra.git"
 
     // do the cherry-pick
     if (cherry_pick) {


### PR DESCRIPTION
Before this patch I got the following error:
21:02:21  WARNING: No such property: rhevm_qe_infra_url for class: job_monitoring
